### PR TITLE
Small bugfix to point pathvariable annotation to the correct variable name

### DIFF
--- a/src/main/java/be/kuleuven/cs/distrinet/gmsa/deltaiot/api/v1/AccountRESTController.java
+++ b/src/main/java/be/kuleuven/cs/distrinet/gmsa/deltaiot/api/v1/AccountRESTController.java
@@ -44,7 +44,7 @@ public class AccountRESTController extends AbstractBaseRESTController {
     }
 
     @PutMapping("{username}")
-    public Account updateAccountInfo(@RequestBody Account updatedAccountInformation, @PathVariable String pathUsername, @RequestHeader(TOKEN_HEADER_NAME) String token) {
+    public Account updateAccountInfo(@RequestBody Account updatedAccountInformation, @PathVariable("username") String pathUsername, @RequestHeader(TOKEN_HEADER_NAME) String token) {
     	var accountFromToken = validateApiToken(token);
     	if (!accountFromToken.isAdmin() && !accountFromToken.getUsername().contentEquals(pathUsername)) {
     		throw new UnauthorizedException("Can only update own account");


### PR DESCRIPTION
Using this method renders an error because the pathname and variable names don't match.
This fix includes the pathvariable name in the annotation.