### PR TITLE
Fix line endings to ensure docker image can be built on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*		text=auto
+Dockerfile	eol=lf
+*.sh		text eol=lf
+mvnw		text eol=lf


### PR DESCRIPTION
add .gitattributes to ensure scripts have the correct line endings on windows for building the docker image